### PR TITLE
Pet Object Support

### DIFF
--- a/UltimateAFK/PlayerEvents.cs
+++ b/UltimateAFK/PlayerEvents.cs
@@ -16,9 +16,12 @@ namespace UltimateAFK
 
 		public void OnPlayerJoin(JoinedEventArgs ev)
 		{
-			// Add a component to the player to check AFK status.
-			AFKComponent afkComponent = ev.Player.GameObject.gameObject.AddComponent<AFKComponent>();
-			afkComponent.plugin = this.plugin;
+			if(ev.Player.IPAddress != "127.0.0.1") // Do not assign AFK component to localized pet objects
+			{
+				// Add a component to the player to check AFK status.
+				AFKComponent afkComponent = ev.Player.GameObject.gameObject.AddComponent<AFKComponent>();
+				afkComponent.plugin = this.plugin;
+			}
 		}
 
 		// This check was moved here, because player's rank's are set AFTER OnPlayerJoin()


### PR DESCRIPTION
Prevents AFK component from assigning to localized pet objects. Unsure if the pet plugins outside of the one Amathor and I use, but this will prevent player objects with the local IP from getting the AFK component and subsequently breaking the server when coupled with Cyanox's DCReplace in addition to setting everyone's HP to -1.